### PR TITLE
Search customization with extra options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk8
+
+install: true
+
+script:
+- mvn clean install

--- a/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
+++ b/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
@@ -125,8 +125,8 @@ public class EntityRepository{
 			nativeSearchQueryBuilder.withIndices(strCategory);
 			nativeSearchQueryBuilder.withTypes(strCategory);
 		}
-		//Support Wildcard and Fuzzy search
-		if(query.contains("*") || query.contains("?") || query.contains("~") || query.contains("^") ) {
+		//Support Wildcard and Fuzzy search. If Any Regular expression is contained, then it must be within /
+		if(query.contains("*") || query.contains("?") || query.contains("~") || query.contains("^") || query.contains("/") ) {
 			nativeSearchQueryBuilder.withQuery(QueryBuilders.queryStringQuery(query)).withPageable(new PageRequest(0, 1000));
 		}
 		else if(query.contains(" OR ") || query.contains(" AND ") || query.contains(" NOT ") || query.contains(" + ") || query.contains(" - ")) { //Boolean Search

--- a/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
+++ b/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
@@ -21,7 +21,6 @@ import org.aksw.simba.autoindex.response.Bindings;
 import org.aksw.simba.autoindex.response.Head;
 import org.aksw.simba.autoindex.response.Response;
 import org.aksw.simba.autoindex.response.Results;
-import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
+++ b/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
@@ -124,7 +124,7 @@ public class EntityRepository{
 			nativeSearchQueryBuilder.withIndices(strCategory);
 			nativeSearchQueryBuilder.withTypes(strCategory);
 		}
-		//Support Wildcard and Fuzzy search. If Any Regular expression is contained, then it must be within /
+		//Support Wild card and Fuzzy search. If Any Regular expression is contained, then it must be within /
 		if(query.contains("*") || query.contains("?") || query.contains("~") || query.contains("^") || query.contains("/") ) {
 			nativeSearchQueryBuilder.withQuery(QueryBuilders.queryStringQuery(query)).withPageable(new PageRequest(0, 1000));
 		}


### PR DESCRIPTION
Support for Search Options similar to whats supported by Lucene and Elastic Search. These include 

1. Proximity Search with ~, For example "AAA"~5.
2. Regular expressions with string contained between / and /. For example /A.B/
3. Wild card search with * and ?.
4. Range Search For example [Aa TO Bb] and {Aa TO Bb}.
5.Boolean Search (OR AND NOT + and -).
6. Fuzzy search with similarity weight For example AA~0.8
7. Term Boosting. For example "AAA"^4 "BBB"
8. Term Grouping with Boolean Search.