### PR TITLE
Search all doesnt work if index is missing

### DIFF
--- a/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
+++ b/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
@@ -118,8 +118,17 @@ public class EntityRepository{
 	
 	public NativeSearchQueryBuilder createNativeSearchQueryBuilder(String query , String strCategory , String strType) {
 		NativeSearchQueryBuilder nativeSearchQueryBuilder = new NativeSearchQueryBuilder();
+		
 		if("all".equals(strCategory)) {
+			//Avoid Index not found issue
+			if(!elasticsearchTemplate.indexExists(categoryProperty)) {
+				elasticsearchTemplate.createIndex(categoryProperty);
+			}
+			if(!elasticsearchTemplate.indexExists(categoryClass)) {
+				elasticsearchTemplate.createIndex(categoryClass);
+			}
 			nativeSearchQueryBuilder.withIndices(categoryClass , categoryEntity , categoryProperty);
+			
 			nativeSearchQueryBuilder.withTypes(categoryClass , categoryEntity , categoryProperty);
 		}
 		else {

--- a/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
+++ b/src/main/java/org/aksw/simba/autoindex/es/repository/EntityRepository.java
@@ -115,20 +115,19 @@ public class EntityRepository{
 		}
 		return strType;
 	}
-	
+	public void checkIndexExists(String indexName) {
+		if(!elasticsearchTemplate.indexExists(indexName)) {
+			elasticsearchTemplate.createIndex(indexName);
+		}
+	}
 	public NativeSearchQueryBuilder createNativeSearchQueryBuilder(String query , String strCategory , String strType) {
 		NativeSearchQueryBuilder nativeSearchQueryBuilder = new NativeSearchQueryBuilder();
 		
 		if("all".equals(strCategory)) {
 			//Avoid Index not found issue
-			if(!elasticsearchTemplate.indexExists(categoryProperty)) {
-				elasticsearchTemplate.createIndex(categoryProperty);
-			}
-			if(!elasticsearchTemplate.indexExists(categoryClass)) {
-				elasticsearchTemplate.createIndex(categoryClass);
-			}
+			checkIndexExists(categoryProperty);
+			checkIndexExists(categoryClass);
 			nativeSearchQueryBuilder.withIndices(categoryClass , categoryEntity , categoryProperty);
-			
 			nativeSearchQueryBuilder.withTypes(categoryClass , categoryEntity , categoryProperty);
 		}
 		else {


### PR DESCRIPTION
Bug fix for Search Query when index doesn't exist. Return empty response instead of current unhandled exception.

Closes #39 